### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -54,7 +54,7 @@ disableInterrupt	KEYWORD2
 enableBatteryInterrupt	KEYWORD2
 enableAlarmInterrupt	KEYWORD2
 
-setEdgeTrigger (KEYWORD2)
+setEdgeTrigger	KEYWORD2
 clearInterrupts	KEYWORD2
 checkBattery	KEYWORD2
 setReferenceVoltage	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords