### PR TITLE
Added functionality to print UNIX Epoch time and read alarm registers

### DIFF
--- a/examples/Example6-Print_Alarm/Example6-Print_Alarm.ino
+++ b/examples/Example6-Print_Alarm/Example6-Print_Alarm.ino
@@ -1,0 +1,74 @@
+/*
+  Prints the alarm date and time from the RV-1805 Real Time Clock
+  By: Andy England
+  SparkFun Electronics
+  Updated by: Adam Garbo
+  Date: 3/14/2020
+  License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
+
+  Feel like supporting our work? Buy a board from SparkFun!
+  https://www.sparkfun.com/products/14642
+
+  This example shows how to print alarm date and time from the RTC.
+
+  Hardware Connections:
+    Attach the Qwiic Shield to your Arduino/Photon/ESP32 or other
+    Plug the RTC into the shield (any port)
+    Open the serial monitor at 9600 baud
+*/
+#include <SparkFun_RV1805.h>
+
+RV1805 rtc;
+
+byte secondsAlarm = 0;
+byte minuteAlarm = 59;
+byte hourAlarm = 23;
+byte dateAlarm = 31;
+byte monthAlarm = 12;
+
+void setup() {
+
+  Wire.begin();
+
+  Serial.begin(115200);
+  while (!Serial);
+  Serial.println("Print RTC Alarm Example");
+  if (rtc.begin() == false) {
+    Serial.println("Something went wrong, check wiring");
+  }
+  
+  // Use the time from the Arduino compiler (build time) to set the RTC
+  // Keep in mind that Arduino does not get the new compiler time every time it compiles. 
+  // To ensure the proper time is loaded, open up a fresh version of the IDE and load the sketch.
+  if (rtc.setToCompilerTime() == false) {
+    Serial.println("Something went wrong setting the time");
+  }
+  Serial.println("RTC online!");
+}
+
+void loop() {
+
+  // Update the time variables from RTC
+  if (rtc.updateTime() == false) {
+    Serial.print("RTC failed to update");
+  }
+
+  // Get the time
+  String currentTime = rtc.stringTimeStamp();
+  Serial.println(currentTime);
+
+  // Set the alarm with the values initialized above
+  rtc.setAlarm(secondsAlarm, minuteAlarm, hourAlarm, dateAlarm, monthAlarm);
+
+  // Print alarm date and time (Note that there is no year alarm register)
+  char alarmBuffer[20];
+  sprintf(alarmBuffer, "2020-%02d-%02dT%02d:%02d:%02d",
+          rtc.getAlarmMonth(),
+          rtc.getAlarmDate(),
+          rtc.getAlarmHours(),
+          rtc.getAlarmMinutes(),
+          rtc.getAlarmSeconds());
+  Serial.println(alarmBuffer);
+
+  delay(5000);
+}

--- a/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
+++ b/examples/Example7-Print_Epoch/Example7-Print_Epoch.ino
@@ -1,0 +1,61 @@
+/*
+  Prints the UNIX Epoch time from the RV-1805 Real Time Clock
+  By: Andy England
+  SparkFun Electronics
+  Updated by: Adam Garbo
+  Date: 3/14/2020
+  License: This code is public domain but you buy me a beer if you use this and we meet someday (Beerware license).
+
+  Feel like supporting our work? Buy a board from SparkFun!
+  https://www.sparkfun.com/products/14642
+
+  This example shows to print the UNIX Epoch time from the RTC.
+
+  Hardware Connections:
+    Attach the Qwiic Shield to your Arduino/Photon/ESP32 or other
+    Plug the RTC into the shield (any port)
+    Open the serial monitor at 9600 baud
+*/
+
+#include <SparkFun_RV1805.h>
+
+RV1805 rtc;
+
+void setup() {
+
+  Wire.begin();
+
+  Serial.begin(115200);
+  while (!Serial);
+  Serial.println("Print UNIX Epoch Time Example");
+  if (rtc.begin() == false) {
+    Serial.println("Something went wrong, check wiring");
+  }
+
+  // Use the time from the Arduino compiler (build time) to set the RTC
+  // Keep in mind that Arduino does not get the new compiler time every time it compiles. 
+  // To ensure the proper time is loaded, open up a fresh version of the IDE and load the sketch.
+  if (rtc.setToCompilerTime() == false) {
+    Serial.println("Something went wrong setting the time");
+  }
+
+  Serial.println("RTC online!");
+}
+
+void loop() {
+
+  // Update the time variables from RTC
+  if (rtc.updateTime() == false) {
+    Serial.print("RTC failed to update");
+  }
+
+  // Get the time
+  String currentTime = rtc.stringTimeStamp();
+  Serial.println(currentTime);
+
+  // Get the UNIX Epoch time
+  unsigned long unixtime = rtc.getEpoch();
+  Serial.println(unixtime);
+
+  delay(1000);
+}

--- a/keywords.txt
+++ b/keywords.txt
@@ -29,6 +29,16 @@ getWeekday	KEYWORD2
 getDate	KEYWORD2
 getMonth	KEYWORD2
 getYear	KEYWORD2
+getEpoch	KEYWORD2
+
+getAlarmHundredths	KEYWORD2
+getAlarmSeconds	KEYWORD2
+getAlarmMinutes	KEYWORD2
+getAlarmHours	KEYWORD2
+getAlarmWeekday	KEYWORD2
+getAlarmDate	KEYWORD2
+getAlarmMonth	KEYWORD2
+getAlarmYear	KEYWORD2
 
 updateTime	KEYWORD2
 stringDateUSA	KEYWORD2

--- a/src/SparkFun_RV1805.cpp
+++ b/src/SparkFun_RV1805.cpp
@@ -6,7 +6,7 @@ February 5, 2018
 https://github.com/sparkfun/Qwiic_RTC
 
 Development environment specifics:
-Arduino IDE 1.6.4
+Arduino IDE 1.8.12
 
 This code is released under the [MIT License](http://opensource.org/licenses/MIT).
 Please review the LICENSE.md file included with this example. If you have any questions
@@ -14,6 +14,7 @@ or concerns with licensing, please contact techsupport@sparkfun.com.
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
+#include <time.h>
 #include "SparkFun_RV1805.h"
 
 //****************************************************************************//
@@ -234,6 +235,23 @@ char* RV1805::stringTimeStamp()
 	return(timeStamp);
 }
 
+uint32_t RV1805::getEpoch()
+{
+  struct tm tm;
+
+  tm.tm_isdst = -1;
+  tm.tm_yday = 0;
+  tm.tm_wday = 0;
+  tm.tm_year = BCDtoDEC(_time[TIME_YEAR]) + 100;
+  tm.tm_mon = BCDtoDEC(_time[TIME_MONTH]) - 1;
+  tm.tm_mday = BCDtoDEC(_time[TIME_DATE]);
+  tm.tm_hour = BCDtoDEC(_time[TIME_HOURS]);
+  tm.tm_min = BCDtoDEC(_time[TIME_MINUTES]);
+  tm.tm_sec = BCDtoDEC(_time[TIME_SECONDS]);
+
+  return mktime(&tm);
+}
+
 bool RV1805::setTime(uint8_t hund, uint8_t sec, uint8_t min, uint8_t hour, uint8_t date, uint8_t month, uint16_t year, uint8_t day)
 {
 	_time[TIME_HUNDREDTHS] = DECtoBCD(hund);
@@ -368,6 +386,43 @@ uint8_t RV1805::getMonth()
 uint8_t RV1805::getYear()
 {
 	return BCDtoDEC(_time[TIME_YEAR]);
+}
+
+
+//Read alarm registers
+uint8_t RV1805::getAlarmHundredths()
+{
+	return BCDtoDEC(readRegister(RV1805_HUNDREDTHS_ALM));
+}
+
+uint8_t RV1805::getAlarmSeconds()
+{
+	return BCDtoDEC(readRegister(RV1805_SECONDS_ALM));
+}
+
+uint8_t RV1805::getAlarmMinutes()
+{
+	return BCDtoDEC(readRegister(RV1805_MINUTES_ALM));
+}
+
+uint8_t RV1805::getAlarmHours()
+{
+	return BCDtoDEC(readRegister(RV1805_HOURS_ALM));
+}
+
+uint8_t RV1805::getAlarmWeekday()
+{
+	return BCDtoDEC(readRegister(RV1805_WEEKDAYS_ALM));
+}
+
+uint8_t RV1805::getAlarmDate()
+{
+	return BCDtoDEC(readRegister(RV1805_DATE_ALM));
+}
+
+uint8_t RV1805::getAlarmMonth()
+{
+	return BCDtoDEC(readRegister(RV1805_MONTHS_ALM));
 }
 
 //Takes the time from the last build and uses it as the current time

--- a/src/SparkFun_RV1805.h
+++ b/src/SparkFun_RV1805.h
@@ -6,11 +6,11 @@ February 5, 2018
 https://github.com/sparkfun/Qwiic_RTC
 
 Resources:
-Uses Wire.h for i2c operation
+Uses Wire.h for I2C operation
 Uses SPI.h for SPI operation
 
 Development environment specifics:
-Arduino IDE 1.6.4
+Arduino IDE 1.8.12
 
 This code is released under the [MIT License](http://opensource.org/licenses/MIT).
 Please review the LICENSE.md file included with this example. If you have any questions 
@@ -194,7 +194,16 @@ class RV1805
 	uint8_t getDate();
 	uint8_t getMonth();
 	uint8_t getYear();	
-	
+	uint32_t getEpoch();
+
+	uint8_t getAlarmHundredths();
+	uint8_t getAlarmSeconds();
+	uint8_t getAlarmMinutes();
+	uint8_t getAlarmHours();
+	uint8_t getAlarmWeekday();
+	uint8_t getAlarmDate();
+	uint8_t getAlarmMonth();
+
 	bool setToCompilerTime(); //Uses the hours, mins, etc from compile time to set RTC
 	
 	bool is12Hour(); //Returns true if 12hour bit is set


### PR DESCRIPTION
Hi Andy (@AndyEngland521), 

After having used the RV-1805 library for the past couple of months, I found myself often needing to program additional functionality. After thoroughly testing these functions, my thoughts were the library and other users may also benefit from them.

My proposed additions include:

1. Adding functions allowing the user to read the alarm registers directly (**_getAlarmSeconds(), getAlarmHours()_**, etc.). Example6-Print_Alarm demonstrates how these functions can be used to print an alarm timestamp, which can be very helpful for keeping track of when alarms are set and/or modified. 

2. Adding a **_getEpoch()_** function that allows the user to print the current date and time as a UNIX Epoch timestamp. This requires including <time.h>. Example7-Print_Epoch demonstrates the use of this function.

It would be handy to add functions that allow for alarms to be set using the Epoch time, but I'm not sure the effort is warranted given that the RV-1805 will likely be replaced in the future.

Cheers,
Adam
