### PR TITLE
Enable Cap_RC Pin

### DIFF
--- a/src/SparkFun_RV1805.cpp
+++ b/src/SparkFun_RV1805.cpp
@@ -83,6 +83,9 @@ boolean RV1805::begin(TwoWire &wirePort)
 	enableTrickleCharge();
 	enableLowPower();
 
+	writeRegister(RV1805_CONF_KEY, RV1805_CONF_WRT); // Enable write access to the CAPRC Register (26h)
+	writeRegister(RV1805_CAP_RC, 0xA0); // Enable Cap_RC pin
+
 	uint8_t setting = readRegister(RV1805_CTRL1);
 	setting |= CTRL1_ARST; //Enables clearing of interrupt flags upon read of status register
 	writeRegister(RV1805_CTRL1, setting);

--- a/src/SparkFun_RV1805.cpp
+++ b/src/SparkFun_RV1805.cpp
@@ -83,8 +83,8 @@ boolean RV1805::begin(TwoWire &wirePort)
 	enableTrickleCharge();
 	enableLowPower();
 
-	writeRegister(RV1805_CONF_KEY, RV1805_CONF_WRT); // Enable write access to the CAPRC Register (26h)
-	writeRegister(RV1805_CAP_RC, 0xA0); // Enable Cap_RC pin
+	writeRegister(RV1805_CONF_KEY, RV1805_CONF_WRT); //Enable write access to the CAPRC Register (26h)
+	writeRegister(RV1805_CAP_RC, 0xA0); //Enable Cap_RC pin
 
 	uint8_t setting = readRegister(RV1805_CTRL1);
 	setting |= CTRL1_ARST; //Enables clearing of interrupt flags upon read of status register

--- a/src/SparkFun_RV1805.cpp
+++ b/src/SparkFun_RV1805.cpp
@@ -80,11 +80,11 @@ boolean RV1805::begin(TwoWire &wirePort)
 	if (sensorPartNumber != RV1805_PART_NUMBER_UPPER) //HW version for RV1805
 		return(false); //Something went wrong. IC didn't respond.
 
-	enableTrickleCharge();
-	enableLowPower();
-
 	writeRegister(RV1805_CONF_KEY, RV1805_CONF_WRT); //Enable write access to the CAPRC Register (26h)
 	writeRegister(RV1805_CAP_RC, 0xA0); //Enable Cap_RC pin
+
+	enableTrickleCharge();
+	enableLowPower();
 
 	uint8_t setting = readRegister(RV1805_CTRL1);
 	setting |= CTRL1_ARST; //Enables clearing of interrupt flags upon read of status register


### PR DESCRIPTION
Hi @AndyEngland521,

A small addition to `begin()` to enable the Cap_RC pin when the device is initialized. Opted to simply use two `writeRegister()` commands instead of creating a separate function. 

Cheers,
Adam